### PR TITLE
Fix for the github issue #33 describeSensor() fails with wrong outputFor...

### DIFF
--- a/R/Constants.R
+++ b/R/Constants.R
@@ -72,8 +72,8 @@ SosSupportedConnectionMethods <- function() {
 
 mimeTypeCSV <- "text/csv"
 mimeTypeXML <- "text/xml"
-mimeTypeOM <- "text/xml;subtype=&quot;om/1.0.0&quot;"
-mimeTypeSML <- "text/xml;subtype=&quot;sensorML/1.0.1&quot;"
+mimeTypeOM <- 'text/xml;subtype="om/1.0.0"'
+mimeTypeSML <- 'text/xml;subtype="sensorML/1.0.1"'
 mimeTypeKML <- "application/vnd.google-earth.kml+xml"
 mimeSubtypeOM <- "\"om/1.0.0\""
 


### PR DESCRIPTION
The caracter (") is now escaped correctly by putting it all inside (' ')